### PR TITLE
Fix IndexOutOfBoundsException with zero-length array (#12)

### DIFF
--- a/src/main/java/jupyter/ToStringDisplayer.java
+++ b/src/main/java/jupyter/ToStringDisplayer.java
@@ -63,10 +63,13 @@ class ToStringDisplayer extends Displayer<Object> {
       Object[] arr = (Object[]) obj;
       StringBuilder sb = new StringBuilder();
 
-      sb.append("[").append(displayElement(arr[0]));
-      for (int i = 1; i < arr.length; i += 1) {
-        String asText = displayElement(arr[i]);
-        sb.append(", ").append(asText);
+      sb.append("[");
+      if (arr.length > 0) {
+        sb.append(displayElement(arr[0]));
+        for (int i = 1; i < arr.length; i += 1) {
+          String asText = displayElement(arr[i]);
+          sb.append(", ").append(asText);
+        }
       }
       sb.append("]");
 

--- a/src/test/java/jupyter/TestToStringDisplayer.java
+++ b/src/test/java/jupyter/TestToStringDisplayer.java
@@ -72,6 +72,9 @@ public class TestToStringDisplayer {
     Assert.assertEquals("Object[]",
         asMap(MIMETypes.TEXT, "[CustomClass(tangerine), null, 34]"),
         toString.display(new Object[] { new CustomClass("tangerine"), null, 34 }));
+    Assert.assertEquals("empty Object[]",
+            asMap(MIMETypes.TEXT, "[]"),
+            toString.display(new Object[] {}));
   }
 
   @Test


### PR DESCRIPTION
Fix `ToStringDisplayer` and add test case for an empty Array to fix #12.