### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.gradle/
+out/


### PR DESCRIPTION
This PR adds a `.gitignore`, with the entries for gradle build output, as gradle is used to build that project. (One doesn't necessarily have or want to have those in a global gitignore, in particular when not using gradle on a daily basis.)