### PR TITLE
Add override of Registration.find accepting default displayer

### DIFF
--- a/src/main/java/jupyter/Registration.java
+++ b/src/main/java/jupyter/Registration.java
@@ -85,13 +85,15 @@ public class Registration {
    * a class, then its interfaces in left-to-right order, then its superclass, the superclass's
    * interfaces, and so on.
    * <p>
-   * The first displayer that can handle the class will be returned.
+   * The first displayer that can handle the class will be returned. If none is found, defaultDisplayer
+   * is returned.
    *
    * @param objClass the class of objects to display
+   * @param defaultDisplayer default Displayer if none is found
    * @return a Displayer instance for this class or one of its superclasses.
    */
   @SuppressWarnings("unchecked")
-  public <T> Displayer<? super T> find(Class<T> objClass) {
+  public <T> Displayer<? super T> find(Class<T> objClass, Displayer<? super T> defaultDisplayer) {
     Set<Class<?>> visited = new HashSet<>();
     visited.add(Object.class); // stop search with Object
     LinkedList<Class<? super T>> classes = new LinkedList<>();
@@ -118,6 +120,26 @@ public class Registration {
     }
 
     return defaultDisplayer;
+  }
+
+  /**
+   * Finds the most specific Displayer instance for a class.
+   * <p>
+   * A displayer is found by checking registrations for the given class, its interfaces, its
+   * superclasses, and each superclass's interfaces using a breadth-first search. The search visits
+   * a class, then its interfaces in left-to-right order, then its superclass, the superclass's
+   * interfaces, and so on.
+   * <p>
+   * The first displayer that can handle the class will be returned.
+   *
+   * @param objClass the class of objects to display
+   * @return a Displayer instance for this class or one of its superclasses.
+   *
+   * @see jupyter.Registration#find(Class, Displayer)
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Displayer<? super T> find(Class<T> objClass) {
+    return find(objClass, defaultDisplayer);
   }
 
   // Visible for testing

--- a/src/test/java/jupyter/TestRegistration.java
+++ b/src/test/java/jupyter/TestRegistration.java
@@ -35,6 +35,9 @@ public class TestRegistration {
   private static class TestObject implements TestInterface {
   }
 
+  private static class TestUnregisteredObject implements TestInterface {
+  }
+
   private static class TestObjectSubclass extends TestObject {
   }
 
@@ -167,6 +170,23 @@ public class TestRegistration {
     Assert.assertEquals("Should return registered displayer for array instance",
         asMap(MIMETypes.TEXT, expectedString),
         Displayers.display(new TestObject[] {}));
+  }
+
+  @Test
+  public void testDefaultDisplayer() {
+    Displayer<Object> expectedDefaultDisplayer = new Displayer<Object>() {
+      @Override
+      public Map<String, String> display(Object obj) {
+        return asMap(MIMETypes.TEXT, "***");
+      }
+    };
+
+    Assert.assertEquals("Should return default displayer for unregistered class",
+            ToStringDisplayer.get(),
+            Displayers.registration().find(TestUnregisteredObject.class));
+    Assert.assertEquals("Should return passed default displayer for unregistered class",
+            expectedDefaultDisplayer,
+            Displayers.registration().find(TestUnregisteredObject.class, expectedDefaultDisplayer));
   }
 
   private Map<String, String> asMap(String mimeType, String asText) {


### PR DESCRIPTION
This PR adds an override of `Registration.find`, accepting a possibly null default displayer.

Context for this is in [almond](https://github.com/almond-sh/almond). almond now checks for jvm-repr displayers, but falls back on the pretty-printers of [Ammonite](https://github.com/lihaoyi/Ammonite). These pretty-printers have a quite different semantic from the displayers of jvm-repr, so that values displayed by one or the other are handled differently in almond. almond can display several values per cells, like in `val n = 2; val m = n + 1` will display both `n` and `m`). So values handled via pretty-printers are aggregated, and then put as a single user expressions field in the [`execute_reply`](https://jupyter-client.readthedocs.io/en/5.2.3/messaging.html#execution-results), whereas things handled via displayers are sent one-by-one to the front-end via [`display_data`](https://jupyter-client.readthedocs.io/en/5.2.3/messaging.html#display-data) messages).

Hence the need to clearly know whether a displayer should display a value or not.

I didn't rely on `Registration.setDefault`, as a `null` currently isn't fine here. Although alternatively, we could have `setDefault` accept `null` (should just be a matter of adjusting [this line](https://github.com/jupyter/jvm-repr/blob/master/src/main/java/jupyter/Registration.java#L54)).