### PR TITLE
Add AsDisplayData interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ See [instructions on JitPack](https://jitpack.io/#jupyter/jvm-repr) for gradle, 
 
 ### Usage - Library authors
 
-Library authors can register conversion code by implementing a `Displayer` and registering it with `Displayers`.
+Library authors can register conversion code either
+- by implementing a `Displayer` and registering it with `Displayers`, or
+- by having classes extend `AsDisplayData`, whose `display` method returns
+how an instance should be displayed.
 
 For example, the following will register a displayer for Vegas graphs:
 
@@ -52,6 +55,25 @@ import vegas.DSL.ExtendedUnitSpecBuilder
         ).asJava
       }
     })
+```
+
+The following has `Thing` be represented as simple text in Jupyter front-ends,
+like `Thing(2)` for `new Thing(2)`:
+```java
+import java.util.HashMap;
+import java.util.Map;
+
+class Thing implements AsDisplayData {
+  private int n;
+  public Thing(int n) {
+    this.n = n;
+  }
+  public Map<String, String> display() {
+    Map<String, String> result = new HashMap<>();
+    result.put(MIMETypes.TEXT, "Thing(" + n + ")");
+    return result;
+  }
+}
 ```
 
 Any kernel implementation can use the method to display Vegas graphs for the DSL

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ ext {
   scalaVersion = '2.11'
 }
 
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
 
 dependencies {
   testCompile 'junit:junit:4.12'

--- a/src/main/java/jupyter/AsDisplayData.java
+++ b/src/main/java/jupyter/AsDisplayData.java
@@ -1,0 +1,19 @@
+package jupyter;
+
+import java.util.Map;
+
+/**
+ * Convenience interface for classes whose display data is known in advance.
+ *
+ * Classes implementing this interface are displayed via the {@link AsDisplayData#display} method
+ * by default, without needing to register a {@link Displayer} in advance.
+ */
+public interface AsDisplayData {
+    Map<String, String> display();
+
+    Displayer<AsDisplayData> displayer = new Displayer<AsDisplayData>() {
+        public Map<String, String> display(AsDisplayData obj) {
+            return obj.display();
+        }
+    };
+}

--- a/src/main/java/jupyter/AsDisplayData.java
+++ b/src/main/java/jupyter/AsDisplayData.java
@@ -4,12 +4,34 @@ import java.util.Map;
 
 /**
  * Convenience interface for classes whose display data is known in advance.
- *
+ * <p>
  * Classes implementing this interface are displayed via the {@link AsDisplayData#display} method
  * by default, without needing to register a {@link Displayer} in advance.
  */
 public interface AsDisplayData {
+  /**
+   * Called to display this object.
+   * <p>
+   * This method should return a map of MIME type strings to representations of
+   * this object in that MIME type.
+   * <p>
+   * To avoid extra conversion, kernels or front-ends can call
+   * {@link #setMimeTypes(String...)} to pass supported MIME types.
+   * Implementations may ignore these MIME type hints.
+   *
+   * @return a Map of representations of this object by MIME type
+   */
   Map<String, String> display();
+
+  /**
+   * Called to pass the MIME types supported by the kernel or front-end.
+   * <p>
+   * Implementations may ignore these MIME type hints.
+   *
+   * @see Displayer#setMimeTypes(String...)
+   *
+   * @param types MIME types that are supported by the kernel
+   */
   default void setMimeTypes(String... types) {
   }
 }

--- a/src/main/java/jupyter/AsDisplayData.java
+++ b/src/main/java/jupyter/AsDisplayData.java
@@ -9,11 +9,7 @@ import java.util.Map;
  * by default, without needing to register a {@link Displayer} in advance.
  */
 public interface AsDisplayData {
-    Map<String, String> display();
-
-    Displayer<AsDisplayData> displayer = new Displayer<AsDisplayData>() {
-        public Map<String, String> display(AsDisplayData obj) {
-            return obj.display();
-        }
-    };
+  Map<String, String> display();
+  default void setMimeTypes(String... types) {
+  }
 }

--- a/src/main/java/jupyter/Registration.java
+++ b/src/main/java/jupyter/Registration.java
@@ -36,6 +36,22 @@ public class Registration {
   private final Map<Class<?>, Displayer<?>> displayers = new HashMap<>();
   private Displayer<Object> defaultDisplayer = ToStringDisplayer.get();
   private String[] mimeTypes = null;
+  private final boolean registerAsDisplayData;
+
+  private void init() {
+    if (registerAsDisplayData) {
+      add(AsDisplayData.class, AsDisplayData.displayer);
+    }
+  }
+
+  public Registration() {
+      this(true);
+  }
+
+  public Registration(boolean registerAsDisplayData) {
+    this.registerAsDisplayData = registerAsDisplayData;
+    init();
+  }
 
   public Map<Class<?>, Displayer<?>> getAll() {
     return Collections.unmodifiableMap(displayers);
@@ -123,5 +139,6 @@ public class Registration {
   // Visible for testing
   void clear() {
     displayers.clear();
+    init();
   }
 }

--- a/src/main/java/jupyter/Registration.java
+++ b/src/main/java/jupyter/Registration.java
@@ -36,7 +36,6 @@ public class Registration {
   private final Map<Class<?>, Displayer<?>> displayers = new HashMap<>();
   private Displayer<Object> defaultDisplayer = ToStringDisplayer.get();
   private String[] mimeTypes = null;
-  private final boolean registerAsDisplayData = true;
 
   private static Displayer<AsDisplayData> asDisplayDataDisplayer = new Displayer<AsDisplayData>() {
     public Map<String, String> display(AsDisplayData obj) {

--- a/src/main/java/jupyter/Registration.java
+++ b/src/main/java/jupyter/Registration.java
@@ -36,20 +36,19 @@ public class Registration {
   private final Map<Class<?>, Displayer<?>> displayers = new HashMap<>();
   private Displayer<Object> defaultDisplayer = ToStringDisplayer.get();
   private String[] mimeTypes = null;
-  private final boolean registerAsDisplayData;
+  private final boolean registerAsDisplayData = true;
+
+  private static Displayer<AsDisplayData> asDisplayDataDisplayer = new Displayer<AsDisplayData>() {
+    public Map<String, String> display(AsDisplayData obj) {
+      return obj.display();
+    }
+  };
 
   private void init() {
-    if (registerAsDisplayData) {
-      add(AsDisplayData.class, AsDisplayData.displayer);
-    }
+    add(AsDisplayData.class, asDisplayDataDisplayer);
   }
 
   public Registration() {
-      this(true);
-  }
-
-  public Registration(boolean registerAsDisplayData) {
-    this.registerAsDisplayData = registerAsDisplayData;
     init();
   }
 

--- a/src/test/java/jupyter/TestAsDisplayData.java
+++ b/src/test/java/jupyter/TestAsDisplayData.java
@@ -1,0 +1,35 @@
+package jupyter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestAsDisplayData {
+
+    private class Thing implements AsDisplayData {
+        private int n;
+        public Thing(int n) {
+            this.n = n;
+        }
+        public Map<String, String> display() {
+            Map<String, String> result = new HashMap<>();
+            result.put(MIMETypes.TEXT, "Thing(" + n + ")");
+            return result;
+        }
+    }
+
+    @Test
+    public void simple() {
+        Map<String, String> expectedResult = new HashMap<>();
+        expectedResult.put(MIMETypes.TEXT, "Thing(2)");
+
+        Thing thing = new Thing(2);
+        Map<String, String> result = Displayers.display(thing);
+        Assert.assertEquals("Should rely on AsDisplayData" + expectedResult + " " + result, expectedResult, result);
+
+        Displayers.registration().clear();
+        Assert.assertEquals("Should rely on AsDisplayData" + expectedResult + " " + result, expectedResult, result);
+    }
+}

--- a/src/test/java/jupyter/TestAsDisplayData.java
+++ b/src/test/java/jupyter/TestAsDisplayData.java
@@ -8,28 +8,28 @@ import java.util.Map;
 
 public class TestAsDisplayData {
 
-    private class Thing implements AsDisplayData {
-        private int n;
-        public Thing(int n) {
-            this.n = n;
-        }
-        public Map<String, String> display() {
-            Map<String, String> result = new HashMap<>();
-            result.put(MIMETypes.TEXT, "Thing(" + n + ")");
-            return result;
-        }
+  private class Thing implements AsDisplayData {
+    private int n;
+    public Thing(int n) {
+      this.n = n;
     }
-
-    @Test
-    public void simple() {
-        Map<String, String> expectedResult = new HashMap<>();
-        expectedResult.put(MIMETypes.TEXT, "Thing(2)");
-
-        Thing thing = new Thing(2);
-        Map<String, String> result = Displayers.display(thing);
-        Assert.assertEquals("Should rely on AsDisplayData" + expectedResult + " " + result, expectedResult, result);
-
-        Displayers.registration().clear();
-        Assert.assertEquals("Should rely on AsDisplayData" + expectedResult + " " + result, expectedResult, result);
+    public Map<String, String> display() {
+      Map<String, String> result = new HashMap<>();
+      result.put(MIMETypes.TEXT, "Thing(" + n + ")");
+      return result;
     }
+  }
+
+  @Test
+  public void simple() {
+    Map<String, String> expectedResult = new HashMap<>();
+    expectedResult.put(MIMETypes.TEXT, "Thing(2)");
+
+    Thing thing = new Thing(2);
+    Map<String, String> result = Displayers.display(thing);
+    Assert.assertEquals("Should rely on AsDisplayData" + expectedResult + " " + result, expectedResult, result);
+
+    Displayers.registration().clear();
+    Assert.assertEquals("Should rely on AsDisplayData" + expectedResult + " " + result, expectedResult, result);
+  }
 }

--- a/src/test/java/jupyter/Thing.java
+++ b/src/test/java/jupyter/Thing.java
@@ -1,0 +1,4 @@
+package jupyter;
+
+public class Thing {
+}


### PR DESCRIPTION
This PR adds a `AsDisplayData` interface. This interface can be implemented by client libraries having classes meant to be displayed a certain way (e.g. plotting or table libraries, …)

Its main point is that `AsDisplayData` is automatically registered. That way users don't have to register displayers beforehand (initializing each library that can display things can end up being cumbersome…).

Currently, it's in the same module as all the rest, but it could possibly be moved to its own dependency-free separate module (`jvm-repr-interface`?), with only the `AsDisplayData` definition (the static initializer can be moved to jvm-repr itself). That way, the overhead for client libraries to depend on it would be minimal…