### PR TITLE
Handle releases on Travis CI via sbt-ci-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 .gradle/
 out/
+
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
 language: scala
 jdk: openjdk8
+git:
+  depth: false
 cache:
   directories:
   - $HOME/.cache
   - $HOME/.ivy2/cache
   - $HOME/.sbt
-script: sbt test
+stages:
+  - name: test
+  - name: release
+    if: (branch = master AND type = push) OR (tag IS present)
+jobs:
+  include:
+  - script: sbt test
+  - stage: release
+    script: sbt ci-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
-language: java
+language: scala
+jdk: openjdk8
+cache:
+  directories:
+  - $HOME/.cache
+  - $HOME/.ivy2/cache
+  - $HOME/.sbt
+script: sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,24 @@
+
+inThisBuild(List(
+  organization := "org.jupyter",
+  homepage := Some(url("https://github.com/jupyter/jvm-repr")),
+  licenses := List("BSD-3-Clause" -> url("https://opensource.org/licenses/BSD-3-Clause")),
+  developers := List(
+    Developer(
+      "jvm-repr",
+      "jvm-repr contributors",
+      "",
+      url("https://github.com/jupyter/jvm-repr/graphs/contributors")
+    )
+  )
+))
+
+name := "jvm-repr"
+
+// pure java project
+autoScalaLibrary := false
+crossVersion := CrossVersion.disabled
+
+// test stuff
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
+fork.in(Test) := true // seems required for the tests to run fine

--- a/build.sbt
+++ b/build.sbt
@@ -22,3 +22,15 @@ crossVersion := CrossVersion.disabled
 // test stuff
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 fork.in(Test) := true // seems required for the tests to run fine
+
+// sbt-dynver doesn't generate correct versions, because tags don't have a
+// 'v' prefix, so we're overriding its logic here
+version := {
+  import sys.process._
+  val describe = Seq("git", "describe", "--tags").!!.trim
+  val latestTag = Seq("git", "describe", "--tags", "--abbrev=0").!!.trim
+  if (describe == latestTag)
+    describe
+  else
+    describe + "-SNAPSHOT"
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")


### PR DESCRIPTION
Don't merge as is.

This requires the variables described [here](https://github.com/olafurpg/sbt-ci-release/#travis) to be set up on Travis CI (by whoever has the rights to do so).

Fixes https://github.com/jupyter/jvm-repr/issues/15.