### PR TITLE
Support generics in displayer registration

### DIFF
--- a/src/main/java/jupyter/Displayers.java
+++ b/src/main/java/jupyter/Displayers.java
@@ -36,7 +36,7 @@ public abstract class Displayers {
    * @param objClass the class of objects to display
    * @param displayer a Displayer instance
    */
-  public static <T> void register(Class<T> objClass, Displayer<T> displayer) {
+  public static <T> void register(Class<T> objClass, Displayer<? extends T> displayer) {
     registration().add(objClass, displayer);
   }
 

--- a/src/main/java/jupyter/Registration.java
+++ b/src/main/java/jupyter/Registration.java
@@ -86,7 +86,7 @@ public class Registration {
    * @param objClass the class of objects to display
    * @param displayer a Displayer instance
    */
-  public <T> void add(Class<T> objClass, Displayer<T> displayer) {
+  public <T> void add(Class<T> objClass, Displayer<? extends T> displayer) {
     if (mimeTypes != null) {
       displayer.setMimeTypes(mimeTypes);
     }

--- a/src/test/java/jupyter/TestRegistration.java
+++ b/src/test/java/jupyter/TestRegistration.java
@@ -42,6 +42,9 @@ public class TestRegistration {
   private static class TestObjectSubclass extends TestObject {
   }
 
+  private interface TestGenericInterface<T> {
+  }
+
   @Before
   @After
   public void clearGlobals() {
@@ -148,6 +151,21 @@ public class TestRegistration {
     Assert.assertEquals("Should return registered displayer for instance",
         asMap(MIMETypes.TEXT, expectedString),
         Displayers.display(new TestObjectSubclass()));
+  }
+
+  @Test
+  public void testGenericInterfaces() {
+    Displayer<TestGenericInterface<?>> expected = new Displayer<TestGenericInterface<?>>() {
+      @Override
+      public Map<String, String> display(TestGenericInterface<?> obj) {
+        return asMap(MIMETypes.TEXT, "foobar");
+      }
+    };
+
+    Displayers.register(TestGenericInterface.class, expected);
+
+    Assert.assertEquals("Should return registered displayer for generic interface",
+        expected, Displayers.registration().find(TestGenericInterface.class));
   }
 
   @Test


### PR DESCRIPTION
Currently [Tablesaw](https://github.com/jtablesaw/tablesaw) registers only its tables. I have a [PR to register `Column`s](https://github.com/jtablesaw/tablesaw/pull/668) as well. However, we have many different column types.

I am registering the column interface, but need to add a `@SupressWarnings` to avoid generics compilation warnings because it forces me to use just `Column` instead of `Column<?>`. I would like to be able to write the code as:

```
    Displayers.register(
        Column.class,
        new Displayer<Column<?>() {
          @Override
          public Map<String, String> display(Column<?> column) {
            new TableDisplay(
                    column.size(),
                    1,
                    Lists.newArrayList(column.name()),
                    new TableDisplay.Element() {
                      @Override
                      public String get(int columnIndex, int rowIndex) {
                        return column.getUnformattedString(rowIndex);
                      }
                    })
                .display();
            return OutputCell.DISPLAYER_HIDDEN;
          }
        });
```
